### PR TITLE
Use line-number-at-pos instead of current-line

### DIFF
--- a/newspeak-mode.el
+++ b/newspeak-mode.el
@@ -241,17 +241,17 @@
 
 (defun newspeak--first-line-in-block-p ()
   "Return TRUE if we are indenting the first line in a code block."
-  (let ((line (current-line)))
+  (let ((line (line-number-at-pos)))
     (save-excursion
       (re-search-backward (rx "["))
-      (= (- line 1) (current-line)))))
+      (= (- line 1) (line-number-at-pos)))))
 
 (defun newspeak--closing-block-p ()
   "Return TRUE if we are indenting the first line in a code block."
-  (let ((line (current-line)))
+  (let ((line (line-number-at-pos)))
     (save-excursion
       (re-search-forward (rx "]"))
-      (= line (current-line)))))
+      (= line (line-number-at-pos)))))
 
 (defun newspeak--column-token (REGEX)
   "Return column of beginning of line containing REGEX."


### PR DESCRIPTION
current-line is defined in array.el and it is necessary to load array.el for using current-line.

And this change fixes following a byte-compile warning.

```
newspeak-mode.el:333:1:Warning: the function ‘current-line’ is not known to be defined.
```